### PR TITLE
Update Dockerfile: Pull base image from MCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:latest
+FROM mcr.microsoft.com/dotnet/runtime:latest
 
 COPY . /app
 


### PR DESCRIPTION
Substituting latest equivalent image from mcr.microsoft.com.
Current guidance is to pull images from mcr.microsoft.com where available instead of Docker Hub. If questions, please reach out to danlep. Thanks!